### PR TITLE
Fix input field styling to maintain consistent width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-
 body {
     font-family: Arial, sans-serif; 
     background-color: #fefefa; 
@@ -13,7 +12,6 @@ body {
     top: 5px; 
     right: 50px; 
 }
-
 
 h1 {
     font-family: "Purple Purse", serif; 
@@ -36,7 +34,7 @@ h1 {
     background-color: #ffffff; 
 }
 
-.input-item {
+.input-item, .input-select {
     width: 100%; 
     max-width: 400px; 
     padding: 10px; 
@@ -44,11 +42,16 @@ h1 {
     border: 1px solid #c0c0c0; 
     border-radius: 5px; 
     transition: border 0.3s ease; 
+    box-sizing: border-box;
 }
 
-.input-item:focus {
+.input-item:focus, .input-select:focus {
     border: 2px solid #264348; 
     outline: none; 
+}
+
+.input-select {
+    appearance: none; /* Remove default dropdown arrow for better customization */
 }
 
 /* Button Styles */
@@ -106,7 +109,7 @@ h2 {
     h1 {
         font-size: 50px; 
     }
-    .input-item {
+    .input-item, .input-select {
         font-size: 16px; 
     }
     #addItemBtn, #submitBtn {


### PR DESCRIPTION
Added .input-select with the same properties as .input-item to ensure the dropdown and input fields match in size.
Included box-sizing: border-box; to ensure padding and border are included in the element's width.
Used appearance: none; on .input-select to remove the default dropdown arrow, making it consistent with other elements if needed.